### PR TITLE
[WIP]商品出品ページのマークアップ

### DIFF
--- a/app/assets/stylesheets/_new.scss
+++ b/app/assets/stylesheets/_new.scss
@@ -1,0 +1,229 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  background-color: #f0f0f0;
+  font-size: 14px;
+  color: #333;
+  margin: 0 auto;
+}
+h1,h2,h3,h4,h5,h6,p {
+  padding: 10px 0;
+  margin: 0;
+}
+
+a{
+  text-decoration: none;
+  color: #0095ee;
+}
+
+/*.header{
+ * background-color: #f8f8f8;
+ * height: 100px;
+ * width: 100vw;
+ * }
+ */
+
+.text-bold{
+  font-weight: bold;
+  margin-bottom: 5px;
+}
+
+.required{
+  color: white;
+  background-color: red;
+  margin-left: 1em;
+  padding: 2px;
+  }
+
+
+$form-font-size: 18px;
+$form-padding: 5px;
+$main-padding: 40px 0 ;
+$main-padding-bottom: 40px;
+$main-border-bottom: 1px solid grey;
+
+
+
+.content {
+  background-color: #f8f8f8;
+  &__main{
+    background-color: white;
+    width: 700px;
+    margin: 0 auto;
+    padding: 20px;
+    &__item-image-box{
+      padding-bottom: $main-padding-bottom;
+      border-bottom: $main-border-bottom;
+    }
+    &__item-name-box{
+      padding: $main-padding;
+      border-bottom: $main-border-bottom;
+      &__item-name-field{
+        width: 100%;
+        font-size: $form-font-size;
+        line-height: 40px;
+        margin-bottom: 20px;
+        padding: $form-padding;
+      }
+      &__item-exp-field{
+        width: 100%;
+        height: 200px;
+        font-size: $form-font-size;
+        padding: $form-padding;
+      }    
+    }
+
+    &__item-info-box{
+      padding: $main-padding;
+      border-bottom: $main-border-bottom;
+      &__headline{
+        margin-bottom: 10px;
+      }
+      &__category{
+        width: 100%;
+        height: 40px;
+        font-size: $form-font-size;
+        margin-bottom: 20px;
+      }
+      &__brand-field{
+        width: 100%;
+        font-size: $form-font-size;
+        line-height: 40px;
+        margin-bottom: 20px;
+        padding: $form-padding;
+      }
+      &__item-status{
+        width: 100%;
+        height: 40px;
+        font-size: $form-font-size;
+      }
+    }
+  
+
+    &__delivery-box{
+      padding: $main-padding;
+      border-bottom: $main-border-bottom;
+      &__headline{
+        margin-bottom: 10px;
+      }
+      &__delivery-fee{
+        width: 100%;
+        height: 40px;
+        font-size: $form-font-size;
+        margin-bottom: 20px;
+      }
+      &__area{
+        width: 100%;
+        height: 40px;
+        font-size: $form-font-size;
+        margin-bottom: 20px;
+      }
+      &__days{
+        width: 100%;
+        height: 40px;
+        font-size: $form-font-size;
+      }
+    }
+    &__price-box{
+      padding: $main-padding;
+      border-bottom: $main-border-bottom;
+      &__headline{
+        margin-bottom: 10px;
+      }
+      &__inner{
+        margin-bottom: 20px;
+        display: flex;
+        justify-content: space-between;
+        &__left-box{
+          width: 50%;
+        }
+        &__right-box{
+          width: 50%;
+          &__price{
+            width: 100%;
+            height: 40px;
+            text-align: right;
+            padding: $form-padding; 
+          }
+        }
+      }
+      &__fee-inner{
+        width: 100%;
+        height: 40px;
+        margin-bottom: 20px;
+        line-height: 40px;
+        display: flex;
+        justify-content: space-between;
+        &__left{
+          // 未定
+        }
+        &__right{
+          // 未定
+        }
+      }
+      
+      &__profit-inner{
+        width: 100%;
+        height: 40px;
+        line-height: 40px;
+        display: flex;
+        justify-content: space-between;
+        &__left{
+          // 未定
+        }
+        &__right{
+          // 未定
+        }
+      }
+      
+      }  
+
+    &__botton-box{
+      padding: $main-padding;
+      border-bottom: $main-border-bottom;
+      text-align: center;
+      display: flex;
+      flex-direction: column;
+      &__send-botton{
+        color: white;
+        background-color: red;
+        font-size: 16px;
+        width: 50%;
+        height: 50px;
+        border: $main-border-bottom;
+        margin: 0 auto 20px;
+        border-radius: 8px;
+        border: none;
+      }
+      &__draft-botton{
+        background-color: #ccc;
+        width: 50%;
+        height: 50px;
+        font-size: 16px;
+        border: 1px solid;
+        margin: 0 auto 20px;
+        border-radius: 8px;
+        border: none;
+
+      }
+      .back-bton{
+        color: #0095ee;
+      }
+    }
+
+    &__warning-box{
+      font-size: 10px;
+      padding: 20px 0 ;
+    }
+  }               
+}
+
+/*.footer{
+ * background-color: #272727;
+ * height: 100px;
+ * width: 100vw;
+*  }
+*/
+

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,5 +2,6 @@
 @import "mixin/cursor-hover";
 @import "mixin/img-size";
 @import "items";
+@import "new";
 @import "font-awesome-sprockets";
 @import "font-awesome";

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -15,6 +15,7 @@
               %span.required
                 必須
             最大10枚までアップロードできます
+            -# カラム名(itemimage)は後で変更
             = f.file_field :itemimage
                           
           .content__main__item-name-box
@@ -22,12 +23,12 @@
               商品名
               %span.required
                 必須
-            = f.text_field :itemname, class:"content__main__item-name-box__item-name-field", placeholder: "40文字まで", maxlength: 40
+            = f.text_field :name, class:"content__main__item-name-box__item-name-field", placeholder: "40文字まで", maxlength: 40
             .text-bold
               商品の説明
               %span.required
                 必須
-            = f.text_area :itemexplanation, class:"content__main__item-name-box__item-exp-field", placeholder: "商品の説明(必須１０００文字以内)\n(色、素材、重さ、定価、注意点など)\n\n例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。", maxlength: 1000
+            = f.text_area :detail, class:"content__main__item-name-box__item-exp-field", placeholder: "商品の説明(必須１０００文字以内)\n(色、素材、重さ、定価、注意点など)\n\n例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。", maxlength: 1000
               
           .content__main__item-info-box
             .content__main__item-info-box__headline
@@ -36,14 +37,17 @@
               カテゴリー
               %span.required
                 必須
+            -# カラム名(category)は後で変更
             = f.select :category, [['レディース', 1], ['メンズ', 2], ['ベビー・キッズ', 3], ['インテリア・住まい・小物', 4], ['本・音楽・ゲーム', 5], ['おもちゃ・ホビー・グッズ', 6], ['コスメ・香水・美容', 7], ['家電・スマホ・カメラ', 8], ['スポーツ・レジャー', 9], ['ハンドメイド', 10], ['チケット', 11], ['自動車・オートバイ', 12], ['その他', 13]], {prompt: "選択してください"}, {class: "content__main__item-info-box__category"} 
             .text-bold
               ブランド
+            -# カラム名(brand)は後で変更
             = f.text_field :brand, class:"content__main__item-info-box__brand-field", placeholder: "例）シャネル"
             .text-bold
               商品の状態
               %span.required
                 必須
+            -# カラム名(itemstatus)は後で変更
             = f.select :itemstatus, [['新品・未使用', 1], ['未使用に近い', 2], ['目立った傷や汚れなし', 3], ['やや傷や汚れあり', 4], ['傷や汚れあり', 5], ['全体的に状態が悪い', 6]], {prompt: "選択してください"}, {class: "content__main__item-info-box__item-status"}
 
           .content__main__delivery-box
@@ -55,17 +59,17 @@
               配送料の負担
               %span.required
                 必須
-            = f.select :deliveryfee, [['送料込み(出品者負担)', 1], ['着払い(購入者負担)', 2]], {prompt: "選択してください"}, {class: "content__main__delivery-box__delivery-fee"} 
+            = f.select :postage, [['送料込み(出品者負担)', 1], ['着払い(購入者負担)', 2]], {prompt: "選択してください"}, {class: "content__main__delivery-box__delivery-fee"} 
             .text-bold
               発送元の地域
               %span.required
                 必須
-            = f.select :area, [['北海道', 1], ['青森県', 2]], {prompt: "選択してください"}, {class: "content__main__delivery-box__area"}
+            = f.select :ship_from, [['北海道', 1], ['青森県', 2]], {prompt: "選択してください"}, {class: "content__main__delivery-box__area"}
             .text-bold
               発送までの日数
               %span.required
                 必須
-            = f.select :days, [['1~2日で発送', 1], ['2~3日で発送', 2], ['4~7日で発送', 3]], {prompt: "選択してください"}, {class: "content__main__delivery-box__days"}
+            = f.select :ship_date, [['1~2日で発送', 1], ['2~3日で発送', 2], ['4~7日で発送', 3]], {prompt: "選択してください"}, {class: "content__main__delivery-box__days"}
 
           .content__main__price-box
             .content__main__price-box__headline

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -1,0 +1,101 @@
+!!!
+%html{lang: "ja"}
+  %head
+    %meta{charset: "utf-8"}
+  %body
+    = render "header"
+    .content
+      .content__main 
+        -# @userの部分は後でモデルクラスのインスタンスに変更        
+        = form_with model: @user do |f|
+ 
+          .content__main__item-image-box
+            .text-bold
+              出品画像
+              %span.required
+                必須
+            最大10枚までアップロードできます
+            = f.file_field :itemimage
+                          
+          .content__main__item-name-box
+            .text-bold
+              商品名
+              %span.required
+                必須
+            = f.text_field :itemname, class:"content__main__item-name-box__item-name-field", placeholder: "40文字まで", maxlength: 40
+            .text-bold
+              商品の説明
+              %span.required
+                必須
+            = f.text_area :itemexplanation, class:"content__main__item-name-box__item-exp-field", placeholder: "商品の説明(必須１０００文字以内)\n(色、素材、重さ、定価、注意点など)\n\n例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。", maxlength: 1000
+              
+          .content__main__item-info-box
+            .content__main__item-info-box__headline
+              商品の詳細
+            .text-bold
+              カテゴリー
+              %span.required
+                必須
+            = f.select :category, [['レディース', 1], ['メンズ', 2], ['ベビー・キッズ', 3], ['インテリア・住まい・小物', 4], ['本・音楽・ゲーム', 5], ['おもちゃ・ホビー・グッズ', 6], ['コスメ・香水・美容', 7], ['家電・スマホ・カメラ', 8], ['スポーツ・レジャー', 9], ['ハンドメイド', 10], ['チケット', 11], ['自動車・オートバイ', 12], ['その他', 13]], {prompt: "選択してください"}, {class: "content__main__item-info-box__category"} 
+            .text-bold
+              ブランド
+            = f.text_field :brand, class:"content__main__item-info-box__brand-field", placeholder: "例）シャネル"
+            .text-bold
+              商品の状態
+              %span.required
+                必須
+            = f.select :itemstatus, [['新品・未使用', 1], ['未使用に近い', 2], ['目立った傷や汚れなし', 3], ['やや傷や汚れあり', 4], ['傷や汚れあり', 5], ['全体的に状態が悪い', 6]], {prompt: "選択してください"}, {class: "content__main__item-info-box__item-status"}
+
+          .content__main__delivery-box
+            -# 「配送について」のリンクは削除してもいいかも
+            .content__main__delivery-box__headline
+              = link_to "#", class: "back-btn" do
+                配送について
+            .text-bold
+              配送料の負担
+              %span.required
+                必須
+            = f.select :deliveryfee, [['送料込み(出品者負担)', 1], ['着払い(購入者負担)', 2]], {prompt: "選択してください"}, {class: "content__main__delivery-box__delivery-fee"} 
+            .text-bold
+              発送元の地域
+              %span.required
+                必須
+            = f.select :area, [['北海道', 1], ['青森県', 2]], {prompt: "選択してください"}, {class: "content__main__delivery-box__area"}
+            .text-bold
+              発送までの日数
+              %span.required
+                必須
+            = f.select :days, [['1~2日で発送', 1], ['2~3日で発送', 2], ['4~7日で発送', 3]], {prompt: "選択してください"}, {class: "content__main__delivery-box__days"}
+
+          .content__main__price-box
+            .content__main__price-box__headline
+              価格(¥300〜9,999,999)
+            .content__main__price-box__inner
+              .content__main__price-box__inner__left-box
+                .text-bold
+                  販売価格
+                  %span.required
+                    必須
+              .content__main__price-box__inner__right-box
+                = f.number_field :price, class:"content__main__price-box__inner__right-box__price", min: 300, max: 9999999
+            .content__main__price-box__fee-inner
+              .content__main__price-box__fee-inner__left
+                販売手数料 (10%)
+              .content__main__price-box__fee-inner__right
+                [販売価格 * 0.1 の合計値が入ります]
+            .content__main__price-box__profit-inner
+              .content__main__price-box__profit-inner__left
+                販売利益
+              .content__main__price-box__profit-inner__right
+                [販売価格 - 手数料 の合計値が入ります]
+            
+
+          .content__main__botton-box
+            = f.submit "出品する", class: "content__main__botton-box__send-botton"
+            = f.submit "下書きに保存", class: "content__main__botton-box__draft-botton"
+            = link_to "#", class: "back-btn" do
+              もどる
+  
+        .content__main__warning-box
+          禁止されている行為および出品物を必ずご確認ください。偽ブランド品や盗品物などの販売は犯罪であり、法律により処罰される可能性があります。 また、出品をもちまして加盟店規約に同意したことになります。
+    = render "footer"


### PR DESCRIPTION
# What
フリマアプリの商品出品ページのマークアップです。
hederとfoterは部分テンプレートで呼び出しています。

数種類のformで構成されているページになっていて、1個のform withタグで全部をくくっているので、一番下のsubmitボタンを押すことによって、全入力欄のデータが一回で送信されるつもりです。

一番最初のform（画像投稿用）は、gemを使って実装するはずなので、とりあえず仮設状態にしてます。
下の方にある販売価格欄のformに関しても、formからの値を取得して、更に計算式を埋め込まなければいけないため、現在は仮設です。


app/assets/stylesheets/application.scss に、
このページ用のscssであるnew.scssを呼び出すための
@import "new";
を付け加えてます


# Why
出品者が出品物の情報を入力するために必要。