### PR TITLE
クレジットカード削除機能

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+/app/assets/images

--- a/app/assets/stylesheets/_credit_cards.scss
+++ b/app/assets/stylesheets/_credit_cards.scss
@@ -48,17 +48,34 @@ a{
         height: 350px;
         padding: 70px;
         border-bottom: 2px solid rgb(243, 241, 241);
+        text-align: center;
         &__title{
-          margin: 30px 0 0 40px;
-          font-size: 16px;
+          font-size: 20px;
+          font-weight: bold;
         }
-        &__add-card{
-          text-align: center;
+        &__registered-credit-card{
+          margin: 20px 120px 0 0;
+          font-size: 16px;
+          p {
+            position: relative;
+            margin-right: 70px;
+            padding-top: 10px;
+          }
+         button {
+          position: absolute;
+          top: 210px;
+          right: 230px;
           background-color: #3CCACE;
-          height: 50px;
-          margin: 24px 50px;
-          border-bottom: 1px solid #eee;
-          line-height: 50px;
+          color: white;
+          height: 35px;
+          border-radius: 5px;
+          font-size: 14px;
+          font-weight: bold;
+         } 
+         img {
+           margin-right: 70px;
+           margin-bottom: 10px;
+         }
         }
           a{
             font-size: 16px;

--- a/app/controllers/credit_cards_controller.rb
+++ b/app/controllers/credit_cards_controller.rb
@@ -16,9 +16,9 @@ class CreditCardsController < ApplicationController
     else
       customer = Payjp::Customer.create(
         card: params['payjp-token'],
-        metadata: {user_id: 1}
+        metadata: {user_id: 1} ###user機能実装後current_user.id"に変更
       ) 
-      @card = CreditCard.new(user_id: 1, customer_id: customer.id, card_id: customer.default_card)
+      @card = CreditCard.new(user_id: 1, customer_id: customer.id, card_id: customer.default_card) ###user機能実装後current_user.id"に変更
       if @card.save
         redirect_to "/credit_cards/show"
       else
@@ -28,9 +28,8 @@ class CreditCardsController < ApplicationController
 end
 
   def destroy #PayjpとCardデータベースを削除
-    card = CreditCard.find_by(user_id: 1)
-    if card.blank?
-    else
+    card = CreditCard.find_by(user_id: 1) ###user機能実装後current_user.id"に変更
+    if card.present?
       Payjp.api_key = Rails.application.credentials[:PAYJP_ACCESS_KEY]
       customer = Payjp::Customer.retrieve(card.customer_id)
       customer.delete
@@ -41,7 +40,7 @@ end
 
 
   def show #Cardのデータpayjpに送り情報を取り出す
-    card = CreditCard.find_by(user_id: 1)
+    card = CreditCard.find_by(user_id: 1) ###user機能実装後current_user.id"に変更
     if card.blank?
       redirect_to new_credit_card_path
     else

--- a/app/controllers/credit_cards_controller.rb
+++ b/app/controllers/credit_cards_controller.rb
@@ -27,6 +27,19 @@ class CreditCardsController < ApplicationController
   end
 end
 
+  def destroy #PayjpとCardデータベースを削除
+    card = CreditCard.find_by(user_id: 1)
+    if card.blank?
+    else
+      Payjp.api_key = Rails.application.credentials[:PAYJP_ACCESS_KEY]
+      customer = Payjp::Customer.retrieve(card.customer_id)
+      customer.delete
+      card.delete
+    end
+      redirect_to new_credit_card_path
+  end
+
+
   def show #Cardのデータpayjpに送り情報を取り出す
     card = CreditCard.find_by(user_id: 1)
     if card.blank?
@@ -35,6 +48,21 @@ end
       Payjp.api_key = Rails.application.credentials[:PAYJP_ACCESS_KEY]
       customer = Payjp::Customer.retrieve(card.customer_id)
       @default_card_information = customer.cards.retrieve(card.card_id)
+      @card_brand = @default_card_information.brand      
+      case @card_brand
+      when "Visa"
+        @card_src = "visa.svg"
+      when "JCB"
+        @card_src = "jcb.svg"
+      when "MasterCard"
+        @card_src = "master-card.svg"
+      when "American Express"
+        @card_src = "american_express.svg"
+      when "Diners Club"
+        @card_src = "dinersclub.svg"
+      when "Discover"
+        @card_src = "discover.svg"
+      end
     end
   end
 end

--- a/app/views/credit_cards/show.html.haml
+++ b/app/views/credit_cards/show.html.haml
@@ -25,8 +25,18 @@
         支払い方法
       .container__main__right-box__inner
         .container__main__right-box__inner__title
-          クレジットカード一覧
-        .container__main__right-box__inner__add-card
-          =link_to "/credit_cards/new", class: "container__main__right-box__add-card__btn" do
-            クレジットカードを追加する 
+          登録済みクレジットカード
+        .container__main__right-box__inner__registered-credit-card
+          = image_tag asset_path("#{@card_src}"), width: '60', height: '40', alt: @card_brand, id: "card_image"
+          %br
+          = "**** **** **** " + @default_card_information.last4
+          %br
+          %p
+            - exp_month = @default_card_information.exp_month.to_s
+            - exp_year = @default_card_information.exp_year.to_s.slice(2,3)
+            = exp_month + " / " + exp_year
+            / credit_card_pathはuer機能実装後にcard_path(current_user.id)に変更
+          = form_tag(credit_card_path, method: :delete, id: 'charge-form',  name: "inputForm") do
+            %input{ type: "hidden", name: "card_id", value: "" }
+            %button.delete-btn 削除する
   = render "items/footer"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
   #購入機能実装時にitemsに対してネスト設定を行う（item_id情報を受け取るため）
   resources :purchases, only: [:index]
 
-  resources :credit_cards, only: [:new, :show] do
+  resources :credit_cards, only: [:new, :show, :destroy] do
     collection do
       post 'pay', to: 'credit_cards#pay'
     end


### PR DESCRIPTION
# What
登録したクレジットカードを削除する機能を実装。具体的には以下の通り。

・ルーティング設定 
・コントローラー設定（destroy追加、登録情報をViewに表示できるようShowにも追記）
・View設定

[GIF](https://gyazo.com/95d086b029c21661982389dcf8443c13)
# Why
フリマアプリの利便性において、クレジットカードの削除・再登録できることは必須機能なため