### PR TITLE
[WIP]トップページの商品一覧カテゴリ別実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -7,6 +7,8 @@ class ItemsController < ApplicationController
   # end
 
   def index
+    @items = Item.limit(3).order('created_at DESC')
+    @mens_items = Item.where(category_id: 196..326
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -8,7 +8,7 @@ class ItemsController < ApplicationController
 
   def index
     @items = Item.limit(3).order('created_at DESC')
-    @mens_items = Item.where(category_id: 196..326
+    @mens_items = Item.where(category_id: 196..326).limit(3).order('created_at DESC')
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -9,6 +9,7 @@ class ItemsController < ApplicationController
   def index
     @items = Item.limit(3).order('created_at DESC')
     @mens_items = Item.where(category_id: 196..326).limit(3).order('created_at DESC')
+    @ladies_items = Item.where(category_id: 1..195).limit(3).order('created_at DESC')
   end
 
   def new

--- a/app/views/items/_main.html.haml
+++ b/app/views/items/_main.html.haml
@@ -109,7 +109,7 @@
               .main__top-pickup-contents__product-box__lists__list__body
                 .main__top-pickup-contents__product-box__lists__list__body__name
                   %h3
-                    product3
+                    = "#{item.name}"
                 .main__top-pickup-contents__product-box__lists__list__body__details
                   %ul
                     %li

--- a/app/views/items/_main.html.haml
+++ b/app/views/items/_main.html.haml
@@ -101,37 +101,18 @@
           %h3
             新規投稿商品   
       .main__top-pickup-contents__product-box__lists
-        -@items.each do |item|
-          .main__top-pickup-contents__product-box__lists__list
-            = link_to "#" do
-              %figure.main__top-pickup-contents__product-box__lists__list__image
-                = image_tag item.images.find_by(item_id: item.id).img_url, size: "220x150",alt: "ICON"
-              .main__top-pickup-contents__product-box__lists__list__body
-                .main__top-pickup-contents__product-box__lists__list__body__name
-                  %h3
-                    = "#{item.name}"
-                .main__top-pickup-contents__product-box__lists__list__body__details
-                  %ul
-                    %li
-                      #{item.price}円
-                    %li.main__top-pickup-contents__product-box__lists__list__body__details__link-icon
-                      %span
-                        ★
-                      ０
-                  %p
-                    (税込)
         .main__top-pickup-contents__product-box__lists__list
           = link_to "#" do
             %figure.main__top-pickup-contents__product-box__lists__list__image
-              = image_tag asset_path("product2.png"), alt: "ICON"
+              = image_tag asset_path("product3.png"), alt: "ICON"
             .main__top-pickup-contents__product-box__lists__list__body
               .main__top-pickup-contents__product-box__lists__list__body__name
                 %h3
-                  product2
+                  product3
               .main__top-pickup-contents__product-box__lists__list__body__details
                 %ul
                   %li
-                    20000円
+                    30000円
                   %li.main__top-pickup-contents__product-box__lists__list__body__details__link-icon
                     %span
                       ★

--- a/app/views/items/_main.html.haml
+++ b/app/views/items/_main.html.haml
@@ -101,6 +101,7 @@
           %h3
             新規投稿商品   
       .main__top-pickup-contents__product-box__lists
+        -@items.each do |item|
         .main__top-pickup-contents__product-box__lists__list
           = link_to "#" do
             %figure.main__top-pickup-contents__product-box__lists__list__image

--- a/app/views/items/_main.html.haml
+++ b/app/views/items/_main.html.haml
@@ -113,7 +113,7 @@
                 .main__top-pickup-contents__product-box__lists__list__body__details
                   %ul
                     %li
-                      30000円
+                      #{item.price}円
                     %li.main__top-pickup-contents__product-box__lists__list__body__details__link-icon
                       %span
                         ★

--- a/app/views/items/_main.html.haml
+++ b/app/views/items/_main.html.haml
@@ -102,24 +102,24 @@
             新規投稿商品   
       .main__top-pickup-contents__product-box__lists
         -@items.each do |item|
-        .main__top-pickup-contents__product-box__lists__list
-          = link_to "#" do
-            %figure.main__top-pickup-contents__product-box__lists__list__image
-              = image_tag asset_path("product3.png"), alt: "ICON"
-            .main__top-pickup-contents__product-box__lists__list__body
-              .main__top-pickup-contents__product-box__lists__list__body__name
-                %h3
-                  product3
-              .main__top-pickup-contents__product-box__lists__list__body__details
-                %ul
-                  %li
-                    30000円
-                  %li.main__top-pickup-contents__product-box__lists__list__body__details__link-icon
-                    %span
-                      ★
-                    ０
-                %p
-                  (税込)
+          .main__top-pickup-contents__product-box__lists__list
+            = link_to "#" do
+              %figure.main__top-pickup-contents__product-box__lists__list__image
+                = image_tag asset_path("product3.png"), alt: "ICON"
+              .main__top-pickup-contents__product-box__lists__list__body
+                .main__top-pickup-contents__product-box__lists__list__body__name
+                  %h3
+                    product3
+                .main__top-pickup-contents__product-box__lists__list__body__details
+                  %ul
+                    %li
+                      30000円
+                    %li.main__top-pickup-contents__product-box__lists__list__body__details__link-icon
+                      %span
+                        ★
+                      ０
+                  %p
+                    (税込)
         .main__top-pickup-contents__product-box__lists__list
           = link_to "#" do
             %figure.main__top-pickup-contents__product-box__lists__list__image

--- a/app/views/items/_main.html.haml
+++ b/app/views/items/_main.html.haml
@@ -99,105 +99,52 @@
       .main__top-pickup-contents__product-box__head
         = link_to "#" do
           %h3
-            新規投稿商品   
+            新着アイテム   
       .main__top-pickup-contents__product-box__lists
-        .main__top-pickup-contents__product-box__lists__list
-          = link_to "#" do
-            %figure.main__top-pickup-contents__product-box__lists__list__image
-              = image_tag asset_path("product3.png"), alt: "ICON"
-            .main__top-pickup-contents__product-box__lists__list__body
-              .main__top-pickup-contents__product-box__lists__list__body__name
-                %h3
-                  product3
-              .main__top-pickup-contents__product-box__lists__list__body__details
-                %ul
-                  %li
-                    30000円
-                  %li.main__top-pickup-contents__product-box__lists__list__body__details__link-icon
-                    %span
-                      ★
-                    ０
-                %p
-                  (税込)                  
-        .main__top-pickup-contents__product-box__lists__list
-          = link_to "#" do
-            %figure.main__top-pickup-contents__product-box__lists__list__image
-              = image_tag asset_path("product1.png"), alt: "ICON"
-            .main__top-pickup-contents__product-box__lists__list__body
-              .main__top-pickup-contents__product-box__lists__list__body__name
-                %h3
-                  product1
-              .main__top-pickup-contents__product-box__lists__list__body__details
-                %ul
-                  %li
-                    10000円
-                  %li.main__top-pickup-contents__product-box__lists__list__body__details__link-icon
-                    %span
-                      ★
-                    ０
-                %p
-                  (税込)      
+        -@items.each do |item|
+          .main__top-pickup-contents__product-box__lists__list
+            = link_to "#" do
+              %figure.main__top-pickup-contents__product-box__lists__list__image
+                = image_tag item.images.find_by(item_id: item.id).img_url, size: "220x150",alt: "ICON"
 
-  %section.main__top-pickup-contents
-    %h2.main__top-pickup-contents__head
-      ピックアップブランド
+              .main__top-pickup-contents__product-box__lists__list__body
+                .main__top-pickup-contents__product-box__lists__list__body__name
+                  %h3
+                    = "#{item.name}"
+                .main__top-pickup-contents__product-box__lists__list__body__details
+                  %ul
+                    %li
+                      #{item.price}円
+                    %li.main__top-pickup-contents__product-box__lists__list__body__details__link-icon
+                      %span
+                        ★
+                      ０
+                  %p
+                    (税込)   
+
     .main__top-pickup-contents__product-box
       .main__top-pickup-contents__product-box__head
         = link_to "#" do
           %h3
-            アーカイバ   
+            メンズ新着アイテム   
       .main__top-pickup-contents__product-box__lists
-        .main__top-pickup-contents__product-box__lists__list
-          = link_to "#" do
-            %figure.main__top-pickup-contents__product-box__lists__list__image
-              = image_tag asset_path("product3.png"), alt: "ICON"
-            .main__top-pickup-contents__product-box__lists__list__body
-              .main__top-pickup-contents__product-box__lists__list__body__name
-                %h3
-                  product3
-              .main__top-pickup-contents__product-box__lists__list__body__details
-                %ul
-                  %li
-                    30000円
-                  %li.main__top-pickup-contents__product-box__lists__list__body__details__link-icon
-                    %span
-                      ★
-                    ０
-                %p
-                  (税込)
-        .main__top-pickup-contents__product-box__lists__list
-          = link_to "#" do
-            %figure.main__top-pickup-contents__product-box__lists__list__image
-              = image_tag asset_path("product2.png"), alt: "ICON"
-            .main__top-pickup-contents__product-box__lists__list__body
-              .main__top-pickup-contents__product-box__lists__list__body__name
-                %h3
-                  product2
-              .main__top-pickup-contents__product-box__lists__list__body__details
-                %ul
-                  %li
-                    20000円
-                  %li.main__top-pickup-contents__product-box__lists__list__body__details__link-icon
-                    %span
-                      ★
-                    ０
-                %p
-                  (税込)                  
-        .main__top-pickup-contents__product-box__lists__list
-          = link_to "#" do
-            %figure.main__top-pickup-contents__product-box__lists__list__image
-              = image_tag asset_path("product1.png"), alt: "ICON"
-            .main__top-pickup-contents__product-box__lists__list__body
-              .main__top-pickup-contents__product-box__lists__list__body__name
-                %h3
-                  product1
-              .main__top-pickup-contents__product-box__lists__list__body__details
-                %ul
-                  %li
-                    10000円
-                  %li.main__top-pickup-contents__product-box__lists__list__body__details__link-icon
-                    %span
-                      ★
-                    ０
-                %p
-                  (税込) 
+        -@mens_items.each do |item|
+          .main__top-pickup-contents__product-box__lists__list
+            = link_to "#" do
+              %figure.main__top-pickup-contents__product-box__lists__list__image
+                = image_tag item.images.find_by(item_id: item.id).img_url, size: "220x150",alt: "ICON"
+
+              .main__top-pickup-contents__product-box__lists__list__body
+                .main__top-pickup-contents__product-box__lists__list__body__name
+                  %h3
+                    = "#{item.name}"
+                .main__top-pickup-contents__product-box__lists__list__body__details
+                  %ul
+                    %li
+                      #{item.price}円
+                    %li.main__top-pickup-contents__product-box__lists__list__body__details__link-icon
+                      %span
+                        ★
+                      ０
+                  %p
+                    (税込) 

--- a/app/views/items/_main.html.haml
+++ b/app/views/items/_main.html.haml
@@ -105,7 +105,7 @@
           .main__top-pickup-contents__product-box__lists__list
             = link_to "#" do
               %figure.main__top-pickup-contents__product-box__lists__list__image
-                = image_tag asset_path("product3.png"), alt: "ICON"
+                = image_tag item.images.find_by(item_id: item.id).img_url, size: "220x150",alt: "ICON"
               .main__top-pickup-contents__product-box__lists__list__body
                 .main__top-pickup-contents__product-box__lists__list__body__name
                   %h3

--- a/app/views/items/_main.html.haml
+++ b/app/views/items/_main.html.haml
@@ -121,6 +121,33 @@
                       ０
                   %p
                     (税込)   
+    
+    .main__top-pickup-contents__product-box
+      .main__top-pickup-contents__product-box__head
+        = link_to "#" do
+          %h3
+            レディース新着アイテム   
+      .main__top-pickup-contents__product-box__lists
+        -@ladies_items.each do |item|
+          .main__top-pickup-contents__product-box__lists__list
+            = link_to "#" do
+              %figure.main__top-pickup-contents__product-box__lists__list__image
+                = image_tag item.images.find_by(item_id: item.id).img_url, size: "220x150",alt: "ICON"
+
+              .main__top-pickup-contents__product-box__lists__list__body
+                .main__top-pickup-contents__product-box__lists__list__body__name
+                  %h3
+                    = "#{item.name}"
+                .main__top-pickup-contents__product-box__lists__list__body__details
+                  %ul
+                    %li
+                      #{item.price}円
+                    %li.main__top-pickup-contents__product-box__lists__list__body__details__link-icon
+                      %span
+                        ★
+                      ０
+                  %p
+                    (税込) 
 
     .main__top-pickup-contents__product-box
       .main__top-pickup-contents__product-box__head


### PR DESCRIPTION
[What]
・トップページに新着商品・メンズ/レディース新着商品をそれぞれ表示するように実装
（items controllerとviews/items/_main.html.hamlの編集）
※売り切れ表示は未実装

[Why]
・新着商品をトップページに一覧表示する機能は必須機能であるため。