### PR TITLE
【追加】送付先情報の氏名・カナ

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@
 ## profilesテーブル
 |Column|Type|Options|
 |------|----|-------|
-|family_name|string|null: false|
-|first_name|string|null: false|
-|family_name_kana|string|null: false|
-|first_name_kana|string|null: false|
+|firstname|string|null: false|
+|lastname|string|null: false|
+|firstname_kana|string|null: false|
+|lastname_kana|string|null: false|
 |birth_year|date|null: false|
 |birth_month|date|null: false|
 |birth_day|date|null: false|
@@ -34,6 +34,10 @@
 ## addressesテーブル
 |Column|Type|Options|
 |------|----|-------|
+|firstname|string|null: false|
+|lastname|string|null: false|
+|firstname_kana|string|null: false|
+|lastname_kana|string|null: false|
 |postal_code|integer|null: false|
 |prefecture|string|null: false|
 |city|string|null: false|

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -51,7 +51,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   end
 
   def address_params
-    params.require(:address).permit(:postal_code, :prefecture, :city, :address, :apartment_name)
+    params.require(:address).permit(:postal_code, :prefecture, :city, :address, :apartment_name, :firstname , :lastname, :firstname_kana, :lastname_kana)
   end
 
 end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,6 +1,11 @@
 class Address < ApplicationRecord
   belongs_to :user, optional: true
 
-  validates :postal_code , :prefecture , :city , :address, presence: true
+  validates :postal_code , :prefecture , :city , :address, :firstname, :lastname, :firstname_kana, :lastname_kana, presence: true
+
+  validates :firstname     , format: {with: /\A[ぁ-んァ-ン一-龥]/}
+  validates :lastname      , format: {with: /\A[ぁ-んァ-ン一-龥]/}
+  validates :firstname_kana, format: {with: /\A[ァ-ンー－]+\z/}
+  validates :lastname_kana , format: {with: /\A[ァ-ンー－]+\z/}
 
 end

--- a/app/views/devise/registrations/address_registration.html.haml
+++ b/app/views/devise/registrations/address_registration.html.haml
@@ -7,28 +7,42 @@
         =render "devise/shared/error_messages", resource: @address
     .user-info-wrapper__main
       .user-info-wrapper__main__head
-        住所情報入力
+        送付先情報入力
         
     .user-info-wrapper__main
       .user-info-wrapper__main__title
+        送付先氏名(全角)
+        %span{class: "must"} 必須
+        .flexbox
+          = f.text_field :firstname, {class: "user-info-wrapper__main__text text-half", placeholder: "例)山田"}
+          = f.text_field :lastname , {class: "user-info-wrapper__main__text text-half", placeholder: "例)太郎"}
+      
+      .user-info-wrapper__main__title
+        送付先氏名カナ(全角)
+        %span{class: "must"} 必須
+        .flexbox
+          = f.text_field :firstname_kana, {class: "user-info-wrapper__main__text text-half", placeholder: "例)ヤマダ"}
+          = f.text_field :lastname_kana , {class: "user-info-wrapper__main__text text-half", placeholder: "例)タロウ"}
+
+      .user-info-wrapper__main__title
         郵便番号
-        %span{class: "require"} 必須
+        %span{class: "must"} 必須
       = f.text_field :postal_code, {class: "user-info-wrapper__main__text", placeholder: "例)123-4567"}
       .user-info-wrapper__main__title
         都道府県
-        %span{class: "require"} 必須
+        %span{class: "must"} 必須
         = f.select :prefecture, ["選択してください","北海道","青森県","岩手県","宮城県","秋田県","山形県","福島県","茨城県","栃木県","群馬県","埼玉県","千葉県","東京都","神奈川県","新潟県","富山県","石川県","福井県","山梨県","長野県","岐阜県","静岡県","愛知県","三重県","滋賀県","京都府","大阪府","兵庫県","奈良県","和歌山県","鳥取県","島根県","岡山県","広島県","山口県","徳島県","香川県","愛媛県","高知県","福岡県","佐賀県","長崎県","熊本県","大分県","宮崎県","鹿児島県","沖縄県"], {}, class: "user-info-wrapper__main__select"
       .user-info-wrapper__main__title
         市区町村
-        %span{class: "require"} 必須
+        %span{class: "must"} 必須
       = f.text_field :city, {class: "user-info-wrapper__main__text", placeholder: "例)港区"}
       .user-info-wrapper__main__title
         番地
-        %span{class: "require"} 必須
+        %span{class: "must"} 必須
       = f.text_field :address, {class: "user-info-wrapper__main__text", placeholder: "例)南青山1-2"}
       .user-info-wrapper__main__title
         建物名
-        %span{class: "any"} 任意
+        %span{class: "any"} （任意）
       = f.text_field :apartment_name, {class: "user-info-wrapper__main__text", placeholder: "例)〇〇ビル"}
       .user-info-wrapper__main__caution
         ※本人情報は正しく入力してください。会員登録後、お時間を頂く場合があります。

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -35,6 +35,10 @@ ja:
         phone_number: 電話番号
         nickname: ニックネーム
       address:  
+        firstname: 名前
+        lastname: 苗字
+        firstname_kana: 名前（カナ）
+        lastname_kana: 苗字（カナ）
         postal_code: 郵便番号
         prefecture: 都道府県
         city: 市区町村

--- a/db/migrate/20200526145728_add_first_name_to_addresses.rb
+++ b/db/migrate/20200526145728_add_first_name_to_addresses.rb
@@ -1,0 +1,5 @@
+class AddFirstNameToAddresses < ActiveRecord::Migration[5.2]
+  def change
+    add_column :addresses, :firstname, :string, null: false
+  end
+end

--- a/db/migrate/20200527023800_add_last_name_to_addresses.rb
+++ b/db/migrate/20200527023800_add_last_name_to_addresses.rb
@@ -1,0 +1,5 @@
+class AddLastNameToAddresses < ActiveRecord::Migration[5.2]
+  def change
+    add_column :addresses, :lastname, :string, null: false
+  end
+end

--- a/db/migrate/20200527023848_add_last_name_kana_to_addresses.rb
+++ b/db/migrate/20200527023848_add_last_name_kana_to_addresses.rb
@@ -1,0 +1,5 @@
+class AddLastNameKanaToAddresses < ActiveRecord::Migration[5.2]
+  def change
+    add_column :addresses, :lastname_kana, :string, null: false
+  end
+end

--- a/db/migrate/20200527023903_add_first_name_kana_to_addresses.rb
+++ b/db/migrate/20200527023903_add_first_name_kana_to_addresses.rb
@@ -1,0 +1,5 @@
+class AddFirstNameKanaToAddresses < ActiveRecord::Migration[5.2]
+  def change
+    add_column :addresses, :firstname_kana, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_21_093839) do
+ActiveRecord::Schema.define(version: 2020_05_27_023903) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -21,6 +21,10 @@ ActiveRecord::Schema.define(version: 2020_05_21_093839) do
     t.string "apartment_name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "firstname", null: false
+    t.string "lastname", null: false
+    t.string "lastname_kana", null: false
+    t.string "firstname_kana", null: false
     t.index ["user_id"], name: "index_addresses_on_user_id"
   end
 

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -1,6 +1,30 @@
 require 'rails_helper'
 describe Address do
   describe '#create_address' do
+    it "firstnameがない場合は登録できないこと" do
+      address = build(:address, firstname: nil)
+      address.valid?
+      expect(address.errors[:firstname]).to include("を入力してください")
+    end
+
+    it "lastnameがない場合は登録できないこと" do
+      address = build(:address, lastname: nil)
+      address.valid?
+      expect(address.errors[:lastname]).to include("を入力してください")
+    end
+
+    it "firstname_kanaがない場合は登録できないこと" do
+      address = build(:address, firstname_kana: nil)
+      address.valid?
+      expect(address.errors[:firstname_kana]).to include("を入力してください")
+    end
+
+    it "lastname_kanaがない場合は登録できないこと" do
+      address = build(:address, lastname_kana: nil)
+      address.valid?
+      expect(address.errors[:lastname_kana]).to include("を入力してください")
+    end
+
     it "postal_codeがない場合は登録できないこと" do
       address = build(:address, postal_code: nil)
       address.valid?


### PR DESCRIPTION
[What]
・新規会員登録の際の送付先情報入力画面に氏名とカナの入力欄を必須項目として追加
・addressテーブルへfirstname, lastname, firstname_kana, lastname_kanaのカラム追加
・Address.rbのバリデーション追加
・Addressモデルのテストコード追加
[![Screenshot from Gyazo](https://gyazo.com/6a0cb56b4fcd2a44ee8e2f313d76fd35/raw)](https://gyazo.com/6a0cb56b4fcd2a44ee8e2f313d76fd35)

[Why]
・新規会員登録の際の必須項目で、本人情報とは別に送付先の氏名も登録する必要があるため。